### PR TITLE
Update slicers.md

### DIFF
--- a/site/docs/slicers.md
+++ b/site/docs/slicers.md
@@ -54,6 +54,7 @@ This is the ONLY gcode you need, delete everything else. Copy paste the followin
 Start GCode
 ```properties
 START_PRINT EXTRUDER_TEMP=[first_layer_temperature] BED_TEMP=[first_layer_bed_temperature]
+M83 ; use relative distances for extrusion
 ```
 
 End GCode


### PR DESCRIPTION
Default config (at least for v-core) assumes absolute values for extrusion. SS uses relative values no matter if "Only custom Start G-Code" is checked or not. Not checking the box however will result in relative gcode being interpreted as absolute coordinates.